### PR TITLE
feat: support `:eq` Arel predicate                                   …

### DIFF
--- a/lib/fetcheable_on_api/filtreable.rb
+++ b/lib/fetcheable_on_api/filtreable.rb
@@ -21,7 +21,7 @@ module FetcheableOnApi
       def filter_by(*attrs)
         options = attrs.extract_options!
         options.symbolize_keys!
-        options.assert_valid_keys(:as, :class_name)
+        options.assert_valid_keys(:as, :class_name, :with)
 
         self.filters_configuration = filters_configuration.dup
 
@@ -58,8 +58,16 @@ module FetcheableOnApi
         values.split(',').map do |value|
           column_name = filters_configuration[column.to_sym].fetch(:as, column)
           klass       = filters_configuration[column.to_sym].fetch(:class_name, collection.klass)
+          predicate   = filters_configuration[column.to_sym].fetch(:with, :ilike)
 
-          klass.arel_table[column_name].matches("%#{value}%")
+          case predicate
+          when :ilike
+            klass.arel_table[column_name].matches("%#{value}%")
+          when :eq
+            klass.arel_table[column_name].eq(value)
+          else
+            raise ArgumentError, "unsupported predicate `#{predicate}`"
+          end
         end.inject(:or)
       end
 


### PR DESCRIPTION
In order to support filtering by columns which are not varchars, such as integers, add support for the `eq` Arel predicate.

More predicates could be added in the future, a list of Arel predicates can be found here: https://www.rubydoc.info/github/rails/arel/Arel/Predications