### PR TITLE
feat: support sorting on lowered attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ class QuestionsController < ActionController::Base
   end
 end
 ```
+
 This allows you to pass a new parameter in the query:
 
 ```bash
@@ -184,6 +185,7 @@ $ curl -X GET \
 ```
 
 FetcheableOnApi support multiple sort fields by allowing comma-separated (U+002C COMMA, “,”) sort fields:
+
 ```ruby
 class QuestionsController < ActionController::Base
   #
@@ -290,6 +292,59 @@ $ curl -X GET \
         "category_id": 1,
         "content": "How to simply sort a collection with this gem ?",
         "answer": "Just add sort_by in your controller and call the apply_fetcheable method"
+    },
+    {
+        "id": 4,
+        "position": 2,
+        "category_id": 2,
+        "content": "Is it so simple?",
+        "answer": "Yes"
+    },
+    {
+        "id": 5,
+        "position": 3,
+        "category_id": 2,
+        "content": "Is this real life?",
+        "answer": "Yes this is real life"
+    }
+]
+```
+
+Furthermore you can sort on `lowered` attributes using the `:lower` option:
+
+```ruby
+class QuestionsController < ActionController::Base
+  #
+  # FetcheableOnApi
+  #
+  sort_by :answer, lower: true
+
+  # GET /questions
+  def index
+    questions = apply_fetcheable(Question.joins(:answer).includes(:answer).all)
+    render json: questions
+  end
+end
+```
+
+```bash
+$ curl -X GET \
+  'http://localhost:3000/questions?sort=position'
+
+[
+    {
+        "id": 3,
+        "position": 1,
+        "category_id": 1,
+        "content": "How to simply sort a collection with this gem ?",
+        "answer": "Just add sort_by in your controller and call the apply_fetcheable method"
+    },
+    {
+        "id": 6,
+        "position": 4,
+        "category_id": 1,
+        "content": "Why am I here?",
+        "answer": "just to demonstrate lowered sort",
     },
     {
         "id": 4,

--- a/lib/fetcheable_on_api/sortable.rb
+++ b/lib/fetcheable_on_api/sortable.rb
@@ -7,8 +7,8 @@ module FetcheableOnApi
     # Supports
     #
     SORT_ORDER = {
-      '+' => :asc,
-      '-' => :desc
+      "+" => :asc,
+      "-" => :desc,
     }.freeze
 
     #
@@ -32,7 +32,7 @@ module FetcheableOnApi
 
         attrs.each do |attr|
           sorts_configuration[attr] ||= {
-            as: attr
+            as: attr,
           }
 
           sorts_configuration[attr] = sorts_configuration[attr].merge(options)
@@ -70,7 +70,10 @@ module FetcheableOnApi
       field = field_for(attr_name)
       return unless belong_to_attributes_for?(klass, field)
 
-      klass.arel_table[field].send(sort_method)
+      attribute = klass.arel_table[field]
+      attribute = attribute.lower if sorts_configuration[attr_name].fetch(:lower, false)
+
+      attribute.send(sort_method)
     end
 
     def class_for(attr_name, collection)
@@ -92,11 +95,11 @@ module FetcheableOnApi
     def format_params(params)
       res = {}
       params
-        .split(',')
+        .split(",")
         .each do |attribute|
-          sort_sign = attribute =~ /\A[+-]/ ? attribute.slice!(0) : '+'
-          res[attribute.to_sym] = SORT_ORDER[sort_sign]
-        end
+        sort_sign = attribute =~ /\A[+-]/ ? attribute.slice!(0) : "+"
+        res[attribute.to_sym] = SORT_ORDER[sort_sign]
+      end
       res
     end
   end


### PR DESCRIPTION
Allow to sort on lowered attributes using `ORDER BY LOWER(attribute) ASC`. 

This is useful in the cases where you want a better sorting option for alphabetical sorting. 

I'd suggest to add support for specifying a collation as the next step towards better sorting options (eg: with PostgreSQL `ORDER BY attribute COLLATE "fr_FR"`.