### PR TITLE
feat: add `:association` option to `Filterable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,10 @@ $ curl -X GET \
 ]
 ```
 
+By default fetcheable_on_api will join the associated model using the
+`class_name` option you have provided. If another association should be used as
+the target, use the `association:` option instead.
+
 Furthermore you can specify one of the supported `Arel` predicate.
 
 ```ruby


### PR DESCRIPTION
This allows to target whichever association you want.

This was an issue when filtering on `has_one` associations or models
which have multiple associations to the same model.

This is an alternative implementation of #19 