### PR TITLE
feat: Implement format option functionality in filterable module

### DIFF
--- a/spec/filterable_spec.rb
+++ b/spec/filterable_spec.rb
@@ -459,4 +459,134 @@ RSpec.describe FetcheableOnApi::Filterable do
       expect(result).to eq(collection)
     end
   end
+
+  describe 'format functionality' do
+    describe 'datetime format' do
+      before do
+        MockController.filters_configuration = {}
+        MockController.filter_by :created_at, with: :eq, format: :datetime
+      end
+
+      it 'converts string timestamps to DateTime objects for single values' do
+        controller.params = ActionController::Parameters.new(filter: { created_at: '1609459200' })
+        
+        expect(controller).to receive(:foa_string_to_datetime).with('1609459200').and_return(DateTime.new(2021, 1, 1))
+        
+        result = controller.send(:apply_filters, collection)
+        expect(collection.where_conditions).not_to be_empty
+      end
+
+      it 'converts comma-separated timestamps for multiple values' do
+        controller.params = ActionController::Parameters.new(filter: { created_at: '1609459200,1640995200' })
+        
+        expect(controller).to receive(:foa_string_to_datetime).with('1609459200').and_return(DateTime.new(2021, 1, 1))
+        expect(controller).to receive(:foa_string_to_datetime).with('1640995200').and_return(DateTime.new(2022, 1, 1))
+        
+        result = controller.send(:apply_filters, collection)
+        expect(collection.where_conditions).not_to be_empty
+      end
+
+      it 'converts array of timestamps' do
+        controller.params = ActionController::Parameters.new(filter: { created_at: ['1609459200', '1640995200'] })
+        
+        expect(controller).to receive(:foa_string_to_datetime).with('1609459200').and_return(DateTime.new(2021, 1, 1))
+        expect(controller).to receive(:foa_string_to_datetime).with('1640995200').and_return(DateTime.new(2022, 1, 1))
+        
+        result = controller.send(:apply_filters, collection)
+        expect(collection.where_conditions).not_to be_empty
+      end
+
+      context 'with between predicate' do
+        before do
+          MockController.filters_configuration = {}
+          MockController.filter_by :created_at, with: :between, format: :datetime
+        end
+
+        it 'converts range timestamps for between predicate' do
+          controller.params = ActionController::Parameters.new(filter: { created_at: '1609459200,1640995200' })
+          
+          expect(controller).to receive(:foa_string_to_datetime).with('1609459200').and_return(DateTime.new(2021, 1, 1))
+          expect(controller).to receive(:foa_string_to_datetime).with('1640995200').and_return(DateTime.new(2022, 1, 1))
+          
+          result = controller.send(:apply_filters, collection)
+          expect(collection.where_conditions).not_to be_empty
+        end
+
+        it 'converts multiple ranges for between predicate' do
+          controller.params = ActionController::Parameters.new(filter: { created_at: ['1609459200,1640995200', '1672531200,1704067200'] })
+          
+          expect(controller).to receive(:foa_string_to_datetime).exactly(4).times.and_return(DateTime.new(2021, 1, 1))
+          
+          result = controller.send(:apply_filters, collection)
+          expect(collection.where_conditions).not_to be_empty
+        end
+      end
+    end
+
+    describe 'string format (default)' do
+      before do
+        MockController.filters_configuration = {}
+        MockController.filter_by :name, with: :eq, format: :string
+      end
+
+      it 'does not convert string values' do
+        controller.params = ActionController::Parameters.new(filter: { name: 'john' })
+        
+        expect(controller).not_to receive(:foa_string_to_datetime)
+        
+        result = controller.send(:apply_filters, collection)
+        expect(collection.where_conditions).not_to be_empty
+      end
+    end
+
+    describe 'array format' do
+      before do
+        MockController.filters_configuration = {}
+        MockController.filter_by :tags, with: :in, format: :array
+      end
+
+      it 'does not convert array values during filtering' do
+        controller.params = ActionController::Parameters.new(filter: { tags: ['tag1', 'tag2'] })
+        
+        expect(controller).not_to receive(:foa_string_to_datetime)
+        
+        result = controller.send(:apply_filters, collection)
+        expect(collection.where_conditions).not_to be_empty
+      end
+    end
+
+    describe '#apply_format_conversion' do
+      it 'converts string to datetime when format is :datetime' do
+        expect(controller).to receive(:foa_string_to_datetime).with('1609459200').and_return(DateTime.new(2021, 1, 1))
+        
+        result = controller.send(:apply_format_conversion, '1609459200', :datetime)
+        expect(result).to be_a(DateTime)
+      end
+
+      it 'converts array elements to datetime when format is :datetime' do
+        expect(controller).to receive(:foa_string_to_datetime).with('1609459200').and_return(DateTime.new(2021, 1, 1))
+        expect(controller).to receive(:foa_string_to_datetime).with('1640995200').and_return(DateTime.new(2022, 1, 1))
+        
+        result = controller.send(:apply_format_conversion, ['1609459200', '1640995200'], :datetime)
+        expect(result).to be_an(Array)
+        expect(result.length).to eq(2)
+        expect(result.first).to be_a(DateTime)
+      end
+
+      it 'returns value unchanged when format is :string' do
+        result = controller.send(:apply_format_conversion, 'test_value', :string)
+        expect(result).to eq('test_value')
+      end
+
+      it 'returns value unchanged when format is :array' do
+        result = controller.send(:apply_format_conversion, ['value1', 'value2'], :array)
+        expect(result).to eq(['value1', 'value2'])
+      end
+
+      it 'returns value unchanged when format is not recognized' do
+        result = controller.send(:apply_format_conversion, 'test_value', :unknown)
+        expect(result).to eq('test_value')
+      end
+    end
+  end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -583,4 +583,31 @@ RSpec.describe 'FetcheableOnApi Integration' do
       expect(FetcheableOnApi).to be_const_defined(:NotImplementedError)
     end
   end
+
+  describe 'format functionality integration' do
+    before do
+      MockIntegrationController.filters_configuration = {}
+      MockIntegrationController.filter_by :created_at, with: :between, format: :datetime
+    end
+
+    context 'with datetime format filtering' do
+      before do
+        controller.params = ActionController::Parameters.new(
+          filter: { created_at: '1609459200,1640995200' }
+        )
+      end
+
+      it 'applies datetime format conversion during filtering' do
+        # Mock the datetime conversion method to verify it's called
+        expect(controller).to receive(:foa_string_to_datetime).with('1609459200').and_return(DateTime.new(2021, 1, 1))
+        expect(controller).to receive(:foa_string_to_datetime).with('1640995200').and_return(DateTime.new(2022, 1, 1))
+
+        result = controller.send(:apply_fetcheable, collection)
+
+        # Verify filtering was applied
+        expect(collection.where_conditions).not_to be_empty
+        expect(result).to eq(collection)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The format option was previously documented but completely non-functional. This implements the missing functionality with proper datetime conversion:

- Added apply_format_conversion method to handle value transformation
- Implemented :datetime format support using foa_string_to_datetime method
- Fixed format processing for all filtering scenarios (single values, arrays, ranges)
- Added comprehensive tests covering all format functionality
- Added integration test to verify end-to-end format processing

The format option now properly converts epoch timestamps to DateTime objects when format: :datetime is specified, making the documented API fully functional.

Fixes #17

🤖 Generated with [Claude Code](https://claude.ai/code)